### PR TITLE
Gh pages

### DIFF
--- a/composed-tree.html
+++ b/composed-tree.html
@@ -6,7 +6,7 @@
 <body>
 <h1>SVG test file embedded in HTML:</h1>
 <p> composed-tree </p>
-<svg viewBox="12 2 654 606" width="654" height="606">
+<svg viewBox="12 2 654 606" width="654" height="606"> 
   <title>A composed tree</title>
   <metadata xmlns:dc="http://purl.org/dc/elements/1.1/">
     <dc:date>2013-07-12 01:16Z</dc:date><!-- Produced by OmniGraffle Professional 5.4.4 -->
@@ -27,16 +27,16 @@
       viewBox="-1 -4 10 8" markerWidth="10" markerHeight="8" color="black">
       <path d="M 8 0 L 0 -3 L 0 3 Z" fill="currentColor" stroke="currentColor" stroke-width="1"/>
     </marker>
-    <g id="plainNode" aria-label="Plain node" role="img"><title>A plain node</title>
+    <g id="plainNode" aria-labelledby="plainNodeLabel" role="img"><title id="plainNodeLabel">A plain node</title>
       <circle r="27" fill="white" filter="url(#Shadow)"/>
       <circle r="27" fill="#084" stroke-width="1" stroke="#000"/>
     </g>
-    <g id="shadowHost">
+    <g id="shadowHost" aria-labelledby="shadowHostLabel" role="img"><title id="shadowHostLabel">A shadow host</title>
       <circle r="27" fill="white" filter="url(#Shadow)"/>
       <circle r="27" fill="#084" stroke="black" stroke-width="1"/>
       <text fill="white" font-family="Helvetica" font-size="12"><tspan x="-20" y="-3">shadow</tspan><tspan x="-10" y="11">host</tspan></text>
     </g>
-    <g id="document">
+    <g id="document" aria-labelledby="documentLabel" role="img"><title id="documentLabel">The document root</title>
       <circle r="27" fill="white" filter="url(#Shadow)"/>
       <circle r="27" fill="#08f" stroke="black" stroke-width="1"/>
       <text fill="white" font-family="Helvetica" font-size="12" font-weight="500" x="-26" y="4">document</text>

--- a/composed-tree.html
+++ b/composed-tree.html
@@ -1,6 +1,12 @@
-<?xml version="1.0"?>
-<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
-<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" version="1.1" viewBox="12 2 654 606" width="654" height="606">
+<!DOCTYPE html>
+<html>
+<head>
+ <title>composed-tree - SVG in HTML</title>
+</title></head>
+<body>
+<h1>SVG test file embedded in HTML:</h1>
+<p> composed-tree </p>
+<svg viewBox="12 2 654 606" width="654" height="606">
   <title>A composed tree</title>
   <metadata xmlns:dc="http://purl.org/dc/elements/1.1/">
     <dc:date>2013-07-12 01:16Z</dc:date><!-- Produced by OmniGraffle Professional 5.4.4 -->
@@ -99,3 +105,4 @@
     </g>
   </g>
 </svg>
+</body></html>

--- a/composed-tree.svg
+++ b/composed-tree.svg
@@ -1,0 +1,97 @@
+<?xml version="1.0"?>
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xl="http://www.w3.org/1999/xlink" version="1.1" viewBox="12 2 654 606" width="654" height="606">
+  <title>A composed tree</title>
+  <metadata xmlns:dc="http://purl.org/dc/elements/1.1/">
+    <dc:date>2013-07-12 01:16Z</dc:date><!-- Produced by OmniGraffle Professional 5.4.4 --></metadata>    
+    <defs aria-hidden="true">
+      <filter id="Shadow" filterUnits="userSpaceOnUse">
+        <feGaussianBlur in="SourceAlpha" result="blur" stdDeviation="3.488"/>
+        <feOffset in="blur" result="offset" dx="0" dy="4"/>
+        <feFlood flood-color="black" flood-opacity=".75" result="flood"/>
+        <feComposite in="flood" in2="offset" operator="in"/>
+      </filter>
+      <font-face font-family="Helvetica" font-size="12" units-per-em="1000" underline-position="-75.683594"
+        underline-thickness="49.316406" slope="0" x-height="522.94922"
+        cap-height="717.28516" ascent="770.01953" descent="-229.98047" font-weight="500">
+        <font-face-src><font-face-name name="Helvetica"/></font-face-src>
+      </font-face>
+      <marker orient="auto" overflow="visible" markerUnits="strokeWidth" id="FilledArrow_Marker"
+        viewBox="-1 -4 10 8" markerWidth="10" markerHeight="8" color="black">
+        <path d="M 8 0 L 0 -3 L 0 3 Z" fill="currentColor" stroke="currentColor" stroke-width="1"/>
+      </marker>
+      <g id="plainNode" aria-label="Plain node" role="img"><title>A plain node</title>
+        <circle r="27" fill="#084" stroke-width="1" stroke="#000"/>
+      </g>
+      <g id="shadowHost">
+        <circle r="27" fill="#084" stroke="black" stroke-width="1"/>
+        <text fill="white" font-family="Helvetica" font-size="12"><tspan x="-20" y="-3">shadow</tspan><tspan x="-10" y="11">host</tspan></text>
+      </g>
+      <g id="document">
+          <circle r="27" fill="#08f" stroke="black" stroke-width="1"/>
+          <text fill="white" font-family="Helvetica" font-size="12" font-weight="500" x="-26" y="4">document</text>
+      </g>
+    </defs>
+    <g stroke="none" stroke-opacity="1" stroke-dasharray="none" fill="none" fill-opacity="1">
+      <title>Composed Trees</title>
+      <g><title>Trees</title>
+        <g id="id1424_Graphic">
+          <rect x="32" y="18" width="614" height="565" fill="white" stroke="black" stroke-width="1"/>
+          <text transform="translate(37 23)" font-family="Helvetica" font-size="12" y="11">composed tree</text>
+        </g>
+      </g>
+      <g><title>Nodes</title>
+        <g>
+          <use xl:href="#plainNode" x="207" y="545"/>
+          <use xl:href="#plainNode" x="280" y="545"/>
+          <use xl:href="#plainNode" x="495" y="433"/>
+          <use xl:href="#shadowHost" x="567" y="433"/>
+          <use xl:href="#plainNode" x="351" y="247"/>
+          <use xl:href="#plainNode" x="207" y="433"/>
+          <use xl:href="#plainNode" x="278" y="433"/>
+          <use xl:href="#document" x="321" y="63"/>
+          <use xl:href="#plainNode" x="279" y="155"/>
+          <use xl:href="#plainNode" x="351" y="155"/>
+          <use xl:href="#shadowHost" x="207" y="247"/>
+          <use xl:href="#plainNode" x="279" y="247"/>
+          <use xl:href="#shadowHost" x="423" y="247"/>
+          <use xl:href="#plainNode" x="423" y="341"/>
+          <use xl:href="#plainNode" x="495" y="341"/>
+          <use xl:href="#shadowHost" x="351" y="433"/>
+          <use xl:href="#plainNode" x="423" y="433"/>
+          <use xl:href="#plainNode" x="135" y="341"/>
+          <use xl:href="#plainNode" x="207" y="341"/>
+          <use xl:href="#plainNode" x="63" y="433"/>
+          <use xl:href="#plainNode" x="135" y="433"/>
+          <use xl:href="#plainNode" x="441" y="545"/>
+          <use xl:href="#plainNode" x="369" y="545"/>
+          <use xl:href="#plainNode" x="609" y="545"/>
+          <use xl:href="#plainNode" x="537" y="545"/>
+        </g>
+       <line x1="223" y1="362" x2="255" y2="403" marker-end="url(#FilledArrow_Marker)" stroke="black" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
+       <line x1="207" y1="368" x2="207" y2="395" marker-end="url(#FilledArrow_Marker)" stroke="black" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
+       <line x1="351" y1="182" x2="351" y2="209" marker-end="url(#FilledArrow_Marker)" stroke="black" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
+       <line x1="511" y1="362" x2="544" y2="403" marker-end="url(#FilledArrow_Marker)" stroke="black" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
+       <line x1="495" y1="368" x2="495" y2="395" marker-end="url(#FilledArrow_Marker)" stroke="black" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
+       <line x1="368" y1="176" x2="400" y2="217" marker-end="url(#FilledArrow_Marker)" stroke="black" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
+       <line x1="279" y1="182" x2="279" y2="209" marker-end="url(#FilledArrow_Marker)" stroke="black" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
+       <line x1="262" y1="176" x2="230" y2="217" marker-end="url(#FilledArrow_Marker)" stroke="black" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
+       <line x1="329" y1="89" x2="339" y2="119" marker-end="url(#FilledArrow_Marker)" stroke="black" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
+       <line x1="309" y1="88" x2="294" y2="120" marker-end="url(#FilledArrow_Marker)" stroke="black" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
+       <line x1="423" y1="368" x2="423" y2="395" marker-end="url(#FilledArrow_Marker)" stroke="black" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
+       <line x1="406" y1="362" x2="374" y2="403" marker-end="url(#FilledArrow_Marker)" stroke="black" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
+       <line x1="135" y1="368" x2="135" y2="395" marker-end="url(#FilledArrow_Marker)" stroke="black" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
+       <line x1="118" y1="362" x2="86" y2="403" marker-end="url(#FilledArrow_Marker)" stroke="black" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
+       <line x1="190" y1="269" x2="158" y2="311" marker-end="url(#FilledArrow_Marker)" stroke="black" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
+       <line x1="207" y1="274" x2="207" y2="303" marker-end="url(#FilledArrow_Marker)" stroke="black" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
+       <line x1="423" y1="274" x2="423" y2="303" marker-end="url(#FilledArrow_Marker)" stroke="black" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
+       <line x1="439" y1="268" x2="472" y2="311" marker-end="url(#FilledArrow_Marker)" stroke="black" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
+       <line x1="329" y1="449" x2="236" y2="522" marker-end="url(#FilledArrow_Marker)" stroke="black" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
+       <line x1="336" y1="456" x2="299" y2="513" marker-end="url(#FilledArrow_Marker)" stroke="black" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
+       <line x1="543" y1="446" x2="401" y2="526" marker-end="url(#FilledArrow_Marker)" stroke="black" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
+       <line x1="576" y1="459" x2="596" y2="510" marker-end="url(#FilledArrow_Marker)" stroke="black" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
+       <line x1="560" y1="459" x2="547" y2="509" marker-end="url(#FilledArrow_Marker)" stroke="black" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
+       <line x1="546" y1="451" x2="469" y2="520.3037" marker-end="url(#FilledArrow_Marker)" stroke="black" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
+     </g>
+   </g>
+</svg>

--- a/composed-tree.svg
+++ b/composed-tree.svg
@@ -21,16 +21,16 @@
       viewBox="-1 -4 10 8" markerWidth="10" markerHeight="8" color="black">
       <path d="M 8 0 L 0 -3 L 0 3 Z" fill="currentColor" stroke="currentColor" stroke-width="1"/>
     </marker>
-    <g id="plainNode" aria-label="Plain node" role="img"><title>A plain node</title>
+    <g id="plainNode" aria-labelledby="plainNodeLabel" role="img"><title id="plainNodeLabel">A plain node</title>
       <circle r="27" fill="white" filter="url(#Shadow)"/>
       <circle r="27" fill="#084" stroke-width="1" stroke="#000"/>
     </g>
-    <g id="shadowHost">
+    <g id="shadowHost" aria-labelledby="shadowHostLabel" role="img"><title id="shadowHostLabel">A shadow host</title>
       <circle r="27" fill="white" filter="url(#Shadow)"/>
       <circle r="27" fill="#084" stroke="black" stroke-width="1"/>
       <text fill="white" font-family="Helvetica" font-size="12"><tspan x="-20" y="-3">shadow</tspan><tspan x="-10" y="11">host</tspan></text>
     </g>
-    <g id="document">
+    <g id="document" aria-labelledby="documentLabel" role="img"><title id="documentLabel">The document root</title>
       <circle r="27" fill="white" filter="url(#Shadow)"/>
       <circle r="27" fill="#08f" stroke="black" stroke-width="1"/>
       <text fill="white" font-family="Helvetica" font-size="12" font-weight="500" x="-26" y="4">document</text>


### PR DESCRIPTION
Instead of relying on navigation to the text node, which only seems to
be supported in Yandex (and presumably other chromium-based) browsers,
make role="img" and use aria-labelledby to point to the title, so
Firefox and maybe some windows systems can navigate the nodes
