### PR TITLE
Clean the tree version

### DIFF
--- a/composed-tree-aria-list.svg
+++ b/composed-tree-aria-list.svg
@@ -21,7 +21,7 @@
       viewBox="-1 -4 10 8" markerWidth="10" markerHeight="8" color="black">
       <path d="M 8 0 L 0 -3 L 0 3 Z" fill="currentColor" stroke="currentColor" stroke-width="1"/>
     </marker>
-    <g id="plainNode" aria-labelledby="plainNodeLabel" role="img">
+    <g id="plainNode" aria-labelledby="plainNodeLabel">
       <title id="plainNodeLabel">A plain node</title>
       <circle r="27" fill="white" filter="url(#Shadow)"/>
       <circle r="27" fill="#084" stroke-width="1" stroke="#000"/>

--- a/composed-tree-aria-list.svg
+++ b/composed-tree-aria-list.svg
@@ -21,7 +21,7 @@
       viewBox="-1 -4 10 8" markerWidth="10" markerHeight="8" color="black">
       <path d="M 8 0 L 0 -3 L 0 3 Z" fill="currentColor" stroke="currentColor" stroke-width="1"/>
     </marker>
-    <g id="plainNode" aria-labelledby="plainNodeLabel">
+    <g id="plainNode" aria-labelledby="plainNodeLabel" role="img">
       <title id="plainNodeLabel">A plain node</title>
       <circle r="27" fill="white" filter="url(#Shadow)"/>
       <circle r="27" fill="#084" stroke-width="1" stroke="#000"/>

--- a/composed-tree-aria-list.svg
+++ b/composed-tree-aria-list.svg
@@ -105,14 +105,14 @@
             <title id="r3l2-label">second child is fourth level, node 2</title></a></g>
 
         <g tabindex="0" id="r3n2" transform="translate(279 247)"
-         role="img listitem" aria-labelledby="r3n2-label plainNodeLabel">
+         role="listitem" aria-labelledby="r3n2-label plainNodeLabel">
           <use xlink:href="#plainNode"/>
           <title id="r3n2-label">Third row, node 2</title></g>
        </g>
 
        <g role="list" id="r3list2">
         <g tabindex="0" id="r3n3" transform="translate(351 247)"
-         role="img listitem" aria-labelledby="r3n3-label plainNodeLabel">
+         role="listitem" aria-labelledby="r3n3-label plainNodeLabel">
           <use xlink:href="#plainNode"/>
           <title id="r3n3-label">Third row, node 3</title></g>
 

--- a/composed-tree-aria-list.svg
+++ b/composed-tree-aria-list.svg
@@ -193,12 +193,12 @@
 
        <g role="list" id="r5list1">
         <g tabindex="0" id="r5n1" transform="translate(63 433)"
-         role="listitem img" aria-labelledby="r5n1-label plainNodeLabel">
+         role="listitem" aria-labelledby="r5n1-label plainNodeLabel">
         <use xlink:href="#plainNode"/>
           <title id="r5n1-label">Fifth row, node 1</title></g>
 
         <g tabindex="0" id="r5n2" transform="translate(135 433)"
-         role="listitem img" aria-labelledby="r5n2-label plainNodeLabel">
+         role="listitem" aria-labelledby="r5n2-label plainNodeLabel">
         <use xlink:href="#plainNode"/>
           <title id="r5n2-label">Fifth row, node 2</title></g>
        </g>
@@ -231,7 +231,7 @@
           <title id="r5l2-label">second child is sixth level, node 2</title></a></g>
 
         <g tabindex="0" id="r5n6" transform="translate(423 433)"
-          role="listitem img" aria-labelledby="r5n6-label plainNodeLabel">
+          role="listitem" aria-labelledby="r5n6-label plainNodeLabel">
           <use xlink:href="#plainNode"/>
           <title id="r5n6-label">Fifth row, node 6</title></g>
        </g>
@@ -267,12 +267,12 @@
 
         <g role="list" id="r6list1">
           <g tabindex="0" id="r6n1" transform="translate(207 545)"
-           role="listitem img" aria-labelledby="r6n1-label plainNodeLabel">
+           role="listitem" aria-labelledby="r6n1-label plainNodeLabel">
           <use xlink:href="#plainNode"/>
             <title id="r6n1-label">Sixth row, node 1</title></g>
 
           <g tabindex="0" id="r6n2" transform="translate(280 545)"
-           role="listitem img" aria-labelledby="r6n2-label plainNodeLabel">
+           role="listitem" aria-labelledby="r6n2-label plainNodeLabel">
           <use xlink:href="#plainNode"/>
             <title id="r6n2-label">Sixth row, node 2</title></g>
         </g>

--- a/composed-tree-aria-list.svg
+++ b/composed-tree-aria-list.svg
@@ -21,16 +21,19 @@
       viewBox="-1 -4 10 8" markerWidth="10" markerHeight="8" color="black">
       <path d="M 8 0 L 0 -3 L 0 3 Z" fill="currentColor" stroke="currentColor" stroke-width="1"/>
     </marker>
-    <g id="plainNode" aria-labelledby="plainNodeLabel" role="img"><title id="plainNodeLabel">A plain node</title>
+    <g id="plainNode" aria-labelledby="plainNodeLabel" role="img">
+      <title id="plainNodeLabel">A plain node</title>
       <circle r="27" fill="white" filter="url(#Shadow)"/>
       <circle r="27" fill="#084" stroke-width="1" stroke="#000"/>
     </g>
-    <g id="shadowHost" aria-labelledby="shadowHostLabel" role="img"><title id="shadowHostLabel">A shadow host</title>
+    <g id="shadowHost" aria-labelledby="shadowHostLabel" role="img">
+      <title id="shadowHostLabel">A shadow host</title>
       <circle r="27" fill="white" filter="url(#Shadow)"/>
       <circle r="27" fill="#084" stroke="black" stroke-width="1"/>
       <text fill="white" font-family="Helvetica" font-size="12"><tspan x="-20" y="-3">shadow</tspan><tspan x="-10" y="11">host</tspan></text>
     </g>
-    <g id="document" aria-labelledby="documentLabel" role="img"><title id="documentLabel">The document root</title>
+    <g id="document" aria-labelledby="documentLabel" role="img">
+      <title id="documentLabel">The document root</title>
       <circle r="27" fill="white" filter="url(#Shadow)"/>
       <circle r="27" fill="#08f" stroke="black" stroke-width="1"/>
       <text fill="white" font-family="Helvetica" font-size="12" font-weight="500" x="-26" y="4">document</text>
@@ -205,12 +208,12 @@
 
        <g role="list" id="r5list2">
         <g tabindex="0" id="r5n3" transform="translate(207 433)"
-         role="listitem img" aria-labelledby="r5n3-label plainNodeLabel">
+         role="listitem " aria-labelledby="r5n3-label plainNodeLabel">
         <use xlink:href="#plainNode"/>
           <title id="r5n3-label">Fifth row, node 3</title></g>
 
         <g tabindex="0" id="r5n4" transform="translate(278 433)"
-         role="listitem img" aria-labelledby="r5n4-label plainNodeLabel">
+         role="listitem " aria-labelledby="r5n4-label plainNodeLabel">
         <use xlink:href="#plainNode"/>
           <title id="r5n4-label">Fifth row, node 4</title></g>
        </g>
@@ -238,7 +241,7 @@
 
         <g role="list" id="r5list4">
           <g tabindex="0" id="r5n7" transform="translate(495 433)"
-            role="listitem img" aria-labelledby="r5n7-label plainNodeLabel">
+            role="listitem " aria-labelledby="r5n7-label plainNodeLabel">
             <use xlink:href="#plainNode"/>
             <title id="r5n7-label">Fifth row, node 7</title></g>
 
@@ -279,22 +282,22 @@
 
         <g role="list" id="r6list2">
           <g tabindex="0" id="r6n3" transform="translate(369 545)"
-            role="listitem img" aria-labelledby="r6n3-label plainNodeLabel">
+            role="listitem" aria-labelledby="r6n3-label plainNodeLabel">
             <use xlink:href="#plainNode"/>
             <title id="r6n3-label">Sixth row, node 3</title></g>
 
           <g tabindex="0" id="r6n4" transform="translate(441 545)"
-            role="listitem img" aria-labelledby="r6n4-label plainNodeLabel">
+            role="listitem" aria-labelledby="r6n4-label plainNodeLabel">
             <use xlink:href="#plainNode"/>
             <title id="r6n4-label">Sixth row, node 4</title></g>
 
           <g tabindex="0" id="r6n5" transform="translate(537 545)"
-            role="listitem img" aria-labelledby="r6n5-label plainNodeLabel">
+            role="listitem" aria-labelledby="r6n5-label plainNodeLabel">
             <use xlink:href="#plainNode"/>
             <title id="r6n5-label">Sixth row, node 5</title></g>
 
           <g tabindex="0" id="r6n6" transform="translate(609 545)"
-            role="listitem img" aria-labelledby="r6n6-label plainNodeLabel">
+            role="listitem" aria-labelledby="r6n6-label plainNodeLabel">
             <use xlink:href="#plainNode"/>
             <title id="r6n6-label">Sixth row, node 6</title></g>
         </g>

--- a/composed-tree-links-inobject.html
+++ b/composed-tree-links-inobject.html
@@ -1,11 +1,11 @@
 <!DOCTYPE html>
 <html>
 <head>
- <title>composed-tree-links - SVG test file as img in HTML</title>
+ <title>composed-tree-links - SVG test file as object in HTML</title>
 </head>
 <body>
-<h1>SVG test file as img in HTML:</h1>
-<p> composed-tree-links </p>
+<h1>SVG as <code>&lt;object&gt;in</code> HTML:</h1>
+<p>The SVG image composed-tree-links included with an <code>&lt;object&gt;in</code> element in an HTML document</p>
 <p><object data="composed-tree-links.svg" width="654" height="606">
 <p>The diagram <a href="composed-tree-links.svg">Composed-Tree.svg</a> shows a graphical tree, representing some nodes in an HTML document's object model.</p>
 <p>The document root node - level 1 - is linked to two second level nodes:<p/>


### PR DESCRIPTION
Don't use role="listitem img" because it causes problems for some browsers to construct lists, and we already have the image role on the use'd element anyway.
