### PR TITLE
Major update

### DIFF
--- a/composed-tree.html
+++ b/composed-tree.html
@@ -4,16 +4,15 @@
  <title>composed-tree - SVG in HTML</title>
 </title></head>
 <body>
-<h1>SVG test file embedded in HTML:</h1>
-<p> composed-tree </p>
+<h1>SVG source for composed-tree directly included in the HTML source:</h1>
 <svg viewBox="12 2 654 606" width="654" height="606"> 
-  <title>A composed tree</title>
+  <title>Aria list version of A composed list</title>
   <metadata xmlns:dc="http://purl.org/dc/elements/1.1/">
     <dc:date>2013-07-12 01:16Z</dc:date><!-- Produced by OmniGraffle Professional 5.4.4 -->
     Fixed by chaals to be more sensible markup and more accessible</metadata>    
   <defs aria-hidden="true">
-    <filter id="Shadow" filterUnits="userSpaceOnUse">
-      <feGaussianBlur in="SourceAlpha" result="blur" stdDeviation="3.488"/>
+    <filter id="Shadow">
+      <feGaussianBlur in="SourceAlpha" result="blur" stdDeviation="1"/>
       <feOffset in="blur" result="offset" dx="0" dy="4"/>
       <feFlood flood-color="black" flood-opacity=".75" result="flood"/>
       <feComposite in="flood" in2="offset" operator="in"/>
@@ -27,16 +26,19 @@
       viewBox="-1 -4 10 8" markerWidth="10" markerHeight="8" color="black">
       <path d="M 8 0 L 0 -3 L 0 3 Z" fill="currentColor" stroke="currentColor" stroke-width="1"/>
     </marker>
-    <g id="plainNode" aria-labelledby="plainNodeLabel" role="img"><title id="plainNodeLabel">A plain node</title>
+    <g id="plainNode" aria-labelledby="plainNodeLabel" role="img">
+      <title id="plainNodeLabel">A plain node</title>
       <circle r="27" fill="white" filter="url(#Shadow)"/>
       <circle r="27" fill="#084" stroke-width="1" stroke="#000"/>
     </g>
-    <g id="shadowHost" aria-labelledby="shadowHostLabel" role="img"><title id="shadowHostLabel">A shadow host</title>
+    <g id="shadowHost" aria-labelledby="shadowHostLabel" role="img">
+      <title id="shadowHostLabel">A shadow host</title>
       <circle r="27" fill="white" filter="url(#Shadow)"/>
       <circle r="27" fill="#084" stroke="black" stroke-width="1"/>
       <text fill="white" font-family="Helvetica" font-size="12"><tspan x="-20" y="-3">shadow</tspan><tspan x="-10" y="11">host</tspan></text>
     </g>
-    <g id="document" aria-labelledby="documentLabel" role="img"><title id="documentLabel">The document root</title>
+    <g id="document" aria-labelledby="documentLabel" role="img">
+      <title id="documentLabel">The document root</title>
       <circle r="27" fill="white" filter="url(#Shadow)"/>
       <circle r="27" fill="#08f" stroke="black" stroke-width="1"/>
       <text fill="white" font-family="Helvetica" font-size="12" font-weight="500" x="-26" y="4">document</text>
@@ -51,67 +53,263 @@
       </g>
     </g>
     <g><title>Nodes</title>
-      <g>
-        <use xlink:href="#document" x="321" y="63"/>
+      <g role="list">
+        <g tabindex="0" id="r1root" transform="translate(321 63)"
+          aria-labelledby="documentLabel" role="listitem"
+          aria-owns="r2list1">
+          <use xlink:href="#document"/>
+        <a xlink:href="#r2n1" aria-labelledby="r1l1-label">
+         <line x1="-12" y1="25" x2="-27" y2="57" marker-end="url(#FilledArrow_Marker)"
+          stroke="black" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
+         <title id="r1l1-label">first child is second level node 1</title></a>
+        <a xlink:href="#r2n2" aria-labelledby="r1l2-label">
+         <line x1="8" y1="26" x2="18" y2="56" marker-end="url(#FilledArrow_Marker)"
+          stroke="black" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
+         <title id="r1l2-label">second child is second level, node 2</title></a></g>
 
-        <use xlink:href="#plainNode" x="279" y="155"/>
-        <use xlink:href="#plainNode" x="351" y="155"/>
+       <g role="list" id="r2list1">
+        <g tabindex="0" id="r2n1" transform="translate(279 155)"
+          aria-labelledby="r2n1-label plainNodeLabel" role="listitem"
+          aria-owns="r3list1">
+         <use id="r2n1" xlink:href="#plainNode"/>
+         <title id="r2n1-label">Second row, node 1</title>
+         <a xlink:href="#r3n1" aria-labelledby="r2l1-label">
+          <line x1="-17" y1="21" x2="-49" y2="62" marker-end="url(#FilledArrow_Marker)"
+           stroke="black" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
+          <title id="r2l1-label">first child is third level, node 1</title></a>
+         <a xlink:href="#r3n2" aria-labelledby="r2l2-label">
+          <line y1="27" y2="54" marker-end="url(#FilledArrow_Marker)"
+           stroke="black" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
+          <title id="r2l2-label">second child is third level, node 2</title></a></g>
 
-        <use xlink:href="#shadowHost" x="207" y="247"/>
-        <use xlink:href="#plainNode" x="279" y="247"/>
-        <use xlink:href="#plainNode" x="351" y="247"/>
-        <use xlink:href="#shadowHost" x="423" y="247"/>
+        <g tabindex="0" id="r2n2" transform="translate(351 155)"
+         aria-labelledby="r2n2-label plainNodeLabel" role="listitem"
+          aria-owns="r3list2">
+          <use xlink:href="#plainNode" />
+         <title id="r2n2-label">Second row, node 2</title>
+         <a xlink:href="#r3n3" aria-labelledby="r2l3-label">
+          <line y1="27" y2="54" marker-end="url(#FilledArrow_Marker)"
+           stroke="black" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
+          <title id="r2l3-label">first child is third level, node 3</title></a>
+         <a xlink:href="#r3n4" aria-labelledby="r2l4-label">
+          <line x1="17" y1="21" x2="49" y2="62" marker-end="url(#FilledArrow_Marker)"
+           stroke="black" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
+          <title id="r2l4-label">second child is third level, node 4</title></a></g>
+       </g>
 
-        <use xlink:href="#plainNode" x="135" y="341"/>
-        <use xlink:href="#plainNode" x="207" y="341"/>
-        <use xlink:href="#plainNode" x="423" y="341"/>
-        <use xlink:href="#plainNode" x="495" y="341"/>
+       <g role="list" id="r3list1">
+        <g tabindex="0" id="r3n1" transform="translate(207 247)"
+         aria-labelledby="r3n1-label shadowHostLabel" role="listitem"
+          aria-owns="r4list1">
+          <use id="r3n1" xlink:href="#shadowHost"/>
+          <title id="r3n1-label">Third row, node 1</title>
+         <a xlink:href="#r4n1" aria-labelledby="r3l1-label">
+           <line x1="-17" y1="22" x2="-49" y2="64" marker-end="url(#FilledArrow_Marker)"
+            stroke="black" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
+            <title id="r3l1-label">first child is fourth level, node 1</title></a>
+         <a xlink:href="#r4n2" aria-labelledby="r3l2-label">
+           <line y1="28" y2="56" marker-end="url(#FilledArrow_Marker)"
+            stroke="black" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
+            <title id="r3l2-label">second child is fourth level, node 2</title></a></g>
 
-        <use xlink:href="#plainNode" x="63" y="433"/>
-        <use xlink:href="#plainNode" x="135" y="433"/>
-        <use xlink:href="#plainNode" x="207" y="433"/>
-        <use xlink:href="#plainNode" x="278" y="433"/>
-        <use xlink:href="#shadowHost" x="351" y="433"/>
-        <use xlink:href="#plainNode" x="423" y="433"/>
-        <use xlink:href="#plainNode" x="495" y="433"/>
-        <use xlink:href="#shadowHost" x="567" y="433"/>
+        <g tabindex="0" id="r3n2" transform="translate(279 247)"
+         role="listitem" aria-labelledby="r3n2-label plainNodeLabel">
+          <use xlink:href="#plainNode"/>
+          <title id="r3n2-label">Third row, node 2</title></g>
+       </g>
 
-        <use xlink:href="#plainNode" x="207" y="545"/>
-        <use xlink:href="#plainNode" x="280" y="545"/>
-        <use xlink:href="#plainNode" x="369" y="545"/>
-        <use xlink:href="#plainNode" x="441" y="545"/>
-        <use xlink:href="#plainNode" x="537" y="545"/>
-        <use xlink:href="#plainNode" x="609" y="545"/>
+       <g role="list" id="r3list2">
+        <g tabindex="0" id="r3n3" transform="translate(351 247)"
+         role="listitem" aria-labelledby="r3n3-label plainNodeLabel">
+          <use xlink:href="#plainNode"/>
+          <title id="r3n3-label">Third row, node 3</title></g>
+
+        <g tabindex="0" id="r3n4" transform="translate(423 247)"
+          aria-labelledby="r3n4-label shadowHostLabel" role="listitem" 
+          aria-owns="r4list2">
+          <use xlink:href="#shadowHost"/>
+          <title id="r3n4-label">Third row, node 4</title>
+          <a xlink:href="#r4n3" aria-labelledby="r3l3-label">
+           <line y1="28" y2="56" marker-end="url(#FilledArrow_Marker)"
+            stroke="black" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
+            <title id="r3l3-label">first child is fourth level, node 3</title></a>
+          <a xlink:href="#r4n1" aria-labelledby="r3l1-label">
+           <line x1="16" y1="21" x2="49" y2="64" marker-end="url(#FilledArrow_Marker)"
+            stroke="black" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
+            <title id="r3l4-label">second child is fourth level, node 4</title></a></g>
+       </g>
+
+       <g role="list" id="r4list1">
+        <g tabindex="0" id="r4n1" transform="translate(135 341)"
+         aria-labelledby="r4n1-label plainNodeLabel" role="listitem" 
+          aria-owns="r5list1">
+        <use xlink:href="#plainNode"/>
+          <title id="r4n1-label">Fourth row, node 1</title>
+          <a xlink:href="#r4n3" aria-labelledby="r4l1-label">
+           <line x1="-17" y1="21" x2="-49" y2="64" marker-end="url(#FilledArrow_Marker)"
+           stroke="black" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
+           <title id="r4l1-label">first child is fifth level, node 1</title></a>
+          <a xlink:href="#r4n3" aria-labelledby="r4l2-label">
+           <line y1="27"  y2="64" marker-end="url(#FilledArrow_Marker)"
+            stroke="black" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
+          <title id="r4l2-label">second child is fifth level, node 2</title></a></g>
+
+        <g tabindex="0" id="r4n2" transform="translate(207 341)"
+         aria-labelledby="r4n2-label plainNodeLabel" role="listitem" 
+          aria-owns="r5list2">
+        <use xlink:href="#plainNode"/>
+          <title id="r4n2-label">Fourth row, node 2</title>
+          <a xlink:href="#r5n3" aria-labelledby="r4l3-label">
+           <line y1="27" y2="54" marker-end="url(#FilledArrow_Marker)"
+            stroke="black" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
+           <title id="r4l3-label">first child is fifth level, node 3</title></a>
+          <a xlink:href="#r5n4" aria-labelledby="r4l4-label">
+           <line x1="16" y1="21" x2="48" y2="64" marker-end="url(#FilledArrow_Marker)"
+            stroke="black" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
+          <title id="r4l4-label">second child is fifth level, node 4</title></a></g>
+       </g>
+
+       <g role="list" id="r4list2">
+        <g tabindex="0" id="r4n3" transform="translate(423 341)"
+         aria-labelledby="r4n3-label plainNodeLabel" role="listitem" 
+          aria-owns="r5list3">
+         <use xlink:href="#plainNode"/>
+          <title id="r4n3-label">Fourth row, node 3</title>
+          <a xlink:href="#r5n5" aria-labelledby="r5l5-label">
+           <line x1="-17" y1="21" x2="-49" y2="64" marker-end="url(#FilledArrow_Marker)"
+           stroke="black" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
+           <title id="42l4-label">first child is fifth level, node 5</title></a>
+          <a xlink:href="#r5n6" aria-labelledby="r4l6-label">
+           <line y1="27" y2="64" marker-end="url(#FilledArrow_Marker)"
+            stroke="black" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
+          <title id="r4l6-label">second child is fifth level, node 6</title></a></g>
+
+        <g tabindex="0" id="r4n4" transform="translate(495 341)"
+         aria-labelledby="r4n4-label plainNodeLabel" role="listitem" 
+          aria-owns="r5list4">
+         <use xlink:href="#plainNode"/>
+          <title id="r4n4-label">Fourth row, node 4</title>
+          <a xlink:href="#r5n7" aria-labelledby="r4l7-label">
+           <line y1="27" y2="64" marker-end="url(#FilledArrow_Marker)"
+            stroke="black" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
+          <title id="r4l7-label">first child is fifth level, node 7</title></a>
+          <a xlink:href="#r5n8" aria-labelledby="r4l8-label">
+           <line x1="16" y1="21" x2="49" y2="64" marker-end="url(#FilledArrow_Marker)"
+            stroke="black" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
+           <title id="r4l8-label">second child is fifth level, node 8</title></a></g>
+       </g>
+
+       <g role="list" id="r5list1">
+        <g tabindex="0" id="r5n1" transform="translate(63 433)"
+         role="listitem" aria-labelledby="r5n1-label plainNodeLabel">
+        <use xlink:href="#plainNode"/>
+          <title id="r5n1-label">Fifth row, node 1</title></g>
+
+        <g tabindex="0" id="r5n2" transform="translate(135 433)"
+         role="listitem" aria-labelledby="r5n2-label plainNodeLabel">
+        <use xlink:href="#plainNode"/>
+          <title id="r5n2-label">Fifth row, node 2</title></g>
+       </g>
+
+       <g role="list" id="r5list2">
+        <g tabindex="0" id="r5n3" transform="translate(207 433)"
+         role="listitem " aria-labelledby="r5n3-label plainNodeLabel">
+        <use xlink:href="#plainNode"/>
+          <title id="r5n3-label">Fifth row, node 3</title></g>
+
+        <g tabindex="0" id="r5n4" transform="translate(278 433)"
+         role="listitem " aria-labelledby="r5n4-label plainNodeLabel">
+        <use xlink:href="#plainNode"/>
+          <title id="r5n4-label">Fifth row, node 4</title></g>
+       </g>
+
+       <g role="list" id="r5list3">
+        <g tabindex="0" id="r5n5" transform="translate(351 433)"
+         aria-labelledby="r5n5-label shadowHostLabel" role="listitem" 
+          aria-owns="r6list1">
+          <use xlink:href="#shadowHost"/>
+          <title id="r5n5-label">Fifth row, node 5</title>
+          <a xlink:href="#r6n1" aria-labelledby="r5l1-label">
+           <line x1="-22" y1="16" x2="-115" y2="89" marker-end="url(#FilledArrow_Marker)"
+            stroke="black" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
+           <title id="r5l1-label">first child is sixth level, node 1</title></a>
+          <a xlink:href="#r6n2" aria-labelledby="r5l2-label">
+           <line x1="-15" y1="23" x2="-52" y2="80" marker-end="url(#FilledArrow_Marker)"
+            stroke="black" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
+          <title id="r5l2-label">second child is sixth level, node 2</title></a></g>
+
+        <g tabindex="0" id="r5n6" transform="translate(423 433)"
+          role="listitem" aria-labelledby="r5n6-label plainNodeLabel">
+          <use xlink:href="#plainNode"/>
+          <title id="r5n6-label">Fifth row, node 6</title></g>
+       </g>
+
+        <g role="list" id="r5list4">
+          <g tabindex="0" id="r5n7" transform="translate(495 433)"
+            role="listitem " aria-labelledby="r5n7-label plainNodeLabel">
+            <use xlink:href="#plainNode"/>
+            <title id="r5n7-label">Fifth row, node 7</title></g>
+
+          <g id="r5n8" transform="translate(567 433)" tabindex="0"
+            aria-labelledby="r5n8-label shadowHostLabel"
+            role="listitem" aria-owns="r6list2">
+            <use xlink:href="#shadowHost"/>
+            <title id="r5n8-label">Fifth row, node 8</title>
+            <a xlink:href="#r6n3" aria-labelledby="r5l3-label">
+              <line x1="-24" y1="13" x2="-166" y2="93" marker-end="url(#FilledArrow_Marker)"
+                stroke="black" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
+              <title id="r5l13-label">first child is sixth level, node 3</title></a>
+            <a xlink:href="#r6n4" aria-labelledby="r5l4-label">
+              <line x1="-23" y1="18" x2="-98" y2="93" marker-end="url(#FilledArrow_Marker)"
+                stroke="black" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
+              <title id="r5l4-label">second child is sixth level, node 4</title></a>
+            <a xlink:href="#r6n5" aria-labelledby="r5l5-label">
+              <line x1="9" y1="26" x2="29" y2="77" marker-end="url(#FilledArrow_Marker)"
+                stroke="black" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
+              <title id="r5l5-label">third child is sixth level, node 5</title></a>
+            <a xlink:href="#r6n6" aria-labelledby="r5l6-label">
+              <line x1="-7" y1="26" x2="-20" y2="76" marker-end="url(#FilledArrow_Marker)"
+                stroke="black" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
+              <title id="r5l6-label">fourth child is sixth level, node 6</title></a></g>
+        </g>
+
+        <g role="list" id="r6list1">
+          <g tabindex="0" id="r6n1" transform="translate(207 545)"
+           role="listitem" aria-labelledby="r6n1-label plainNodeLabel">
+          <use xlink:href="#plainNode"/>
+            <title id="r6n1-label">Sixth row, node 1</title></g>
+
+          <g tabindex="0" id="r6n2" transform="translate(280 545)"
+           role="listitem" aria-labelledby="r6n2-label plainNodeLabel">
+          <use xlink:href="#plainNode"/>
+            <title id="r6n2-label">Sixth row, node 2</title></g>
+        </g>
+
+        <g role="list" id="r6list2">
+          <g tabindex="0" id="r6n3" transform="translate(369 545)"
+            role="listitem" aria-labelledby="r6n3-label plainNodeLabel">
+            <use xlink:href="#plainNode"/>
+            <title id="r6n3-label">Sixth row, node 3</title></g>
+
+          <g tabindex="0" id="r6n4" transform="translate(441 545)"
+            role="listitem" aria-labelledby="r6n4-label plainNodeLabel">
+            <use xlink:href="#plainNode"/>
+            <title id="r6n4-label">Sixth row, node 4</title></g>
+
+          <g tabindex="0" id="r6n5" transform="translate(537 545)"
+            role="listitem" aria-labelledby="r6n5-label plainNodeLabel">
+            <use xlink:href="#plainNode"/>
+            <title id="r6n5-label">Sixth row, node 5</title></g>
+
+          <g tabindex="0" id="r6n6" transform="translate(609 545)"
+            role="listitem" aria-labelledby="r6n6-label plainNodeLabel">
+            <use xlink:href="#plainNode"/>
+            <title id="r6n6-label">Sixth row, node 6</title></g>
+        </g>
+
       </g>
-      <line x1="309" y1="88" x2="294" y2="120" marker-end="url(#FilledArrow_Marker)" stroke="black" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
-      <line x1="329" y1="89" x2="339" y2="119" marker-end="url(#FilledArrow_Marker)" stroke="black" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
-
-      <line x1="262" y1="176" x2="230" y2="217" marker-end="url(#FilledArrow_Marker)" stroke="black" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
-      <line x1="279" y1="182" x2="279" y2="209" marker-end="url(#FilledArrow_Marker)" stroke="black" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
-      <line x1="351" y1="182" x2="351" y2="209" marker-end="url(#FilledArrow_Marker)" stroke="black" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
-      <line x1="368" y1="176" x2="400" y2="217" marker-end="url(#FilledArrow_Marker)" stroke="black" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
-
-      <line x1="190" y1="269" x2="158" y2="311" marker-end="url(#FilledArrow_Marker)" stroke="black" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
-      <line x1="207" y1="274" x2="207" y2="303" marker-end="url(#FilledArrow_Marker)" stroke="black" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
-      <line x1="423" y1="274" x2="423" y2="303" marker-end="url(#FilledArrow_Marker)" stroke="black" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
-      <line x1="439" y1="268" x2="472" y2="311" marker-end="url(#FilledArrow_Marker)" stroke="black" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
-
-      <line x1="118" y1="362" x2="86" y2="403" marker-end="url(#FilledArrow_Marker)" stroke="black" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
-      <line x1="135" y1="368" x2="135" y2="395" marker-end="url(#FilledArrow_Marker)" stroke="black" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
-      <line x1="207" y1="368" x2="207" y2="395" marker-end="url(#FilledArrow_Marker)" stroke="black" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
-      <line x1="223" y1="362" x2="255" y2="403" marker-end="url(#FilledArrow_Marker)" stroke="black" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
-      <line x1="406" y1="362" x2="374" y2="403" marker-end="url(#FilledArrow_Marker)" stroke="black" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
-      <line x1="423" y1="368" x2="423" y2="395" marker-end="url(#FilledArrow_Marker)" stroke="black" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
-      <line x1="495" y1="368" x2="495" y2="395" marker-end="url(#FilledArrow_Marker)" stroke="black" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
-      <line x1="511" y1="362" x2="544" y2="403" marker-end="url(#FilledArrow_Marker)" stroke="black" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
-
-      <line x1="329" y1="449" x2="236" y2="522" marker-end="url(#FilledArrow_Marker)" stroke="black" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
-      <line x1="336" y1="456" x2="299" y2="513" marker-end="url(#FilledArrow_Marker)" stroke="black" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
-      <line x1="543" y1="446" x2="401" y2="526" marker-end="url(#FilledArrow_Marker)" stroke="black" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
-      <line x1="546" y1="451" x2="469" y2="520.3037" marker-end="url(#FilledArrow_Marker)" stroke="black" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
-      <line x1="576" y1="459" x2="596" y2="510" marker-end="url(#FilledArrow_Marker)" stroke="black" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
-      <line x1="560" y1="459" x2="547" y2="509" marker-end="url(#FilledArrow_Marker)" stroke="black" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
     </g>
   </g>
 </svg>
+
 </body></html>

--- a/composed-tree.svg
+++ b/composed-tree.svg
@@ -1,13 +1,13 @@
 <?xml version="1.0"?>
 <!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
 <svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" version="1.1" viewBox="12 2 654 606" width="654" height="606">
-  <title>A composed tree</title>
+  <title>Aria list version of A composed list</title>
   <metadata xmlns:dc="http://purl.org/dc/elements/1.1/">
     <dc:date>2013-07-12 01:16Z</dc:date><!-- Produced by OmniGraffle Professional 5.4.4 -->
     Fixed by chaals to be more sensible markup and more accessible</metadata>    
   <defs aria-hidden="true">
-    <filter id="Shadow" filterUnits="userSpaceOnUse">
-      <feGaussianBlur in="SourceAlpha" result="blur" stdDeviation="3.488"/>
+    <filter id="Shadow">
+      <feGaussianBlur in="SourceAlpha" result="blur" stdDeviation="1"/>
       <feOffset in="blur" result="offset" dx="0" dy="4"/>
       <feFlood flood-color="black" flood-opacity=".75" result="flood"/>
       <feComposite in="flood" in2="offset" operator="in"/>
@@ -21,16 +21,19 @@
       viewBox="-1 -4 10 8" markerWidth="10" markerHeight="8" color="black">
       <path d="M 8 0 L 0 -3 L 0 3 Z" fill="currentColor" stroke="currentColor" stroke-width="1"/>
     </marker>
-    <g id="plainNode" aria-labelledby="plainNodeLabel" role="img"><title id="plainNodeLabel">A plain node</title>
+    <g id="plainNode" aria-labelledby="plainNodeLabel" role="img">
+      <title id="plainNodeLabel">A plain node</title>
       <circle r="27" fill="white" filter="url(#Shadow)"/>
       <circle r="27" fill="#084" stroke-width="1" stroke="#000"/>
     </g>
-    <g id="shadowHost" aria-labelledby="shadowHostLabel" role="img"><title id="shadowHostLabel">A shadow host</title>
+    <g id="shadowHost" aria-labelledby="shadowHostLabel" role="img">
+      <title id="shadowHostLabel">A shadow host</title>
       <circle r="27" fill="white" filter="url(#Shadow)"/>
       <circle r="27" fill="#084" stroke="black" stroke-width="1"/>
       <text fill="white" font-family="Helvetica" font-size="12"><tspan x="-20" y="-3">shadow</tspan><tspan x="-10" y="11">host</tspan></text>
     </g>
-    <g id="document" aria-labelledby="documentLabel" role="img"><title id="documentLabel">The document root</title>
+    <g id="document" aria-labelledby="documentLabel" role="img">
+      <title id="documentLabel">The document root</title>
       <circle r="27" fill="white" filter="url(#Shadow)"/>
       <circle r="27" fill="#08f" stroke="black" stroke-width="1"/>
       <text fill="white" font-family="Helvetica" font-size="12" font-weight="500" x="-26" y="4">document</text>
@@ -45,66 +48,261 @@
       </g>
     </g>
     <g><title>Nodes</title>
-      <g>
-        <use xlink:href="#document" x="321" y="63"/>
+      <g role="list">
+        <g tabindex="0" id="r1root" transform="translate(321 63)"
+          aria-labelledby="documentLabel" role="listitem"
+          aria-owns="r2list1">
+          <use xlink:href="#document"/>
+        <a xlink:href="#r2n1" aria-labelledby="r1l1-label">
+         <line x1="-12" y1="25" x2="-27" y2="57" marker-end="url(#FilledArrow_Marker)"
+          stroke="black" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
+         <title id="r1l1-label">first child is second level node 1</title></a>
+        <a xlink:href="#r2n2" aria-labelledby="r1l2-label">
+         <line x1="8" y1="26" x2="18" y2="56" marker-end="url(#FilledArrow_Marker)"
+          stroke="black" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
+         <title id="r1l2-label">second child is second level, node 2</title></a></g>
 
-        <use xlink:href="#plainNode" x="279" y="155"/>
-        <use xlink:href="#plainNode" x="351" y="155"/>
+       <g role="list" id="r2list1">
+        <g tabindex="0" id="r2n1" transform="translate(279 155)"
+          aria-labelledby="r2n1-label plainNodeLabel" role="listitem"
+          aria-owns="r3list1">
+         <use id="r2n1" xlink:href="#plainNode"/>
+         <title id="r2n1-label">Second row, node 1</title>
+         <a xlink:href="#r3n1" aria-labelledby="r2l1-label">
+          <line x1="-17" y1="21" x2="-49" y2="62" marker-end="url(#FilledArrow_Marker)"
+           stroke="black" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
+          <title id="r2l1-label">first child is third level, node 1</title></a>
+         <a xlink:href="#r3n2" aria-labelledby="r2l2-label">
+          <line y1="27" y2="54" marker-end="url(#FilledArrow_Marker)"
+           stroke="black" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
+          <title id="r2l2-label">second child is third level, node 2</title></a></g>
 
-        <use xlink:href="#shadowHost" x="207" y="247"/>
-        <use xlink:href="#plainNode" x="279" y="247"/>
-        <use xlink:href="#plainNode" x="351" y="247"/>
-        <use xlink:href="#shadowHost" x="423" y="247"/>
+        <g tabindex="0" id="r2n2" transform="translate(351 155)"
+         aria-labelledby="r2n2-label plainNodeLabel" role="listitem"
+          aria-owns="r3list2">
+          <use xlink:href="#plainNode" />
+         <title id="r2n2-label">Second row, node 2</title>
+         <a xlink:href="#r3n3" aria-labelledby="r2l3-label">
+          <line y1="27" y2="54" marker-end="url(#FilledArrow_Marker)"
+           stroke="black" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
+          <title id="r2l3-label">first child is third level, node 3</title></a>
+         <a xlink:href="#r3n4" aria-labelledby="r2l4-label">
+          <line x1="17" y1="21" x2="49" y2="62" marker-end="url(#FilledArrow_Marker)"
+           stroke="black" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
+          <title id="r2l4-label">second child is third level, node 4</title></a></g>
+       </g>
 
-        <use xlink:href="#plainNode" x="135" y="341"/>
-        <use xlink:href="#plainNode" x="207" y="341"/>
-        <use xlink:href="#plainNode" x="423" y="341"/>
-        <use xlink:href="#plainNode" x="495" y="341"/>
+       <g role="list" id="r3list1">
+        <g tabindex="0" id="r3n1" transform="translate(207 247)"
+         aria-labelledby="r3n1-label shadowHostLabel" role="listitem"
+          aria-owns="r4list1">
+          <use id="r3n1" xlink:href="#shadowHost"/>
+          <title id="r3n1-label">Third row, node 1</title>
+         <a xlink:href="#r4n1" aria-labelledby="r3l1-label">
+           <line x1="-17" y1="22" x2="-49" y2="64" marker-end="url(#FilledArrow_Marker)"
+            stroke="black" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
+            <title id="r3l1-label">first child is fourth level, node 1</title></a>
+         <a xlink:href="#r4n2" aria-labelledby="r3l2-label">
+           <line y1="28" y2="56" marker-end="url(#FilledArrow_Marker)"
+            stroke="black" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
+            <title id="r3l2-label">second child is fourth level, node 2</title></a></g>
 
-        <use xlink:href="#plainNode" x="63" y="433"/>
-        <use xlink:href="#plainNode" x="135" y="433"/>
-        <use xlink:href="#plainNode" x="207" y="433"/>
-        <use xlink:href="#plainNode" x="278" y="433"/>
-        <use xlink:href="#shadowHost" x="351" y="433"/>
-        <use xlink:href="#plainNode" x="423" y="433"/>
-        <use xlink:href="#plainNode" x="495" y="433"/>
-        <use xlink:href="#shadowHost" x="567" y="433"/>
+        <g tabindex="0" id="r3n2" transform="translate(279 247)"
+         role="listitem" aria-labelledby="r3n2-label plainNodeLabel">
+          <use xlink:href="#plainNode"/>
+          <title id="r3n2-label">Third row, node 2</title></g>
+       </g>
 
-        <use xlink:href="#plainNode" x="207" y="545"/>
-        <use xlink:href="#plainNode" x="280" y="545"/>
-        <use xlink:href="#plainNode" x="369" y="545"/>
-        <use xlink:href="#plainNode" x="441" y="545"/>
-        <use xlink:href="#plainNode" x="537" y="545"/>
-        <use xlink:href="#plainNode" x="609" y="545"/>
+       <g role="list" id="r3list2">
+        <g tabindex="0" id="r3n3" transform="translate(351 247)"
+         role="listitem" aria-labelledby="r3n3-label plainNodeLabel">
+          <use xlink:href="#plainNode"/>
+          <title id="r3n3-label">Third row, node 3</title></g>
+
+        <g tabindex="0" id="r3n4" transform="translate(423 247)"
+          aria-labelledby="r3n4-label shadowHostLabel" role="listitem" 
+          aria-owns="r4list2">
+          <use xlink:href="#shadowHost"/>
+          <title id="r3n4-label">Third row, node 4</title>
+          <a xlink:href="#r4n3" aria-labelledby="r3l3-label">
+           <line y1="28" y2="56" marker-end="url(#FilledArrow_Marker)"
+            stroke="black" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
+            <title id="r3l3-label">first child is fourth level, node 3</title></a>
+          <a xlink:href="#r4n1" aria-labelledby="r3l1-label">
+           <line x1="16" y1="21" x2="49" y2="64" marker-end="url(#FilledArrow_Marker)"
+            stroke="black" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
+            <title id="r3l4-label">second child is fourth level, node 4</title></a></g>
+       </g>
+
+       <g role="list" id="r4list1">
+        <g tabindex="0" id="r4n1" transform="translate(135 341)"
+         aria-labelledby="r4n1-label plainNodeLabel" role="listitem" 
+          aria-owns="r5list1">
+        <use xlink:href="#plainNode"/>
+          <title id="r4n1-label">Fourth row, node 1</title>
+          <a xlink:href="#r4n3" aria-labelledby="r4l1-label">
+           <line x1="-17" y1="21" x2="-49" y2="64" marker-end="url(#FilledArrow_Marker)"
+           stroke="black" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
+           <title id="r4l1-label">first child is fifth level, node 1</title></a>
+          <a xlink:href="#r4n3" aria-labelledby="r4l2-label">
+           <line y1="27"  y2="64" marker-end="url(#FilledArrow_Marker)"
+            stroke="black" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
+          <title id="r4l2-label">second child is fifth level, node 2</title></a></g>
+
+        <g tabindex="0" id="r4n2" transform="translate(207 341)"
+         aria-labelledby="r4n2-label plainNodeLabel" role="listitem" 
+          aria-owns="r5list2">
+        <use xlink:href="#plainNode"/>
+          <title id="r4n2-label">Fourth row, node 2</title>
+          <a xlink:href="#r5n3" aria-labelledby="r4l3-label">
+           <line y1="27" y2="54" marker-end="url(#FilledArrow_Marker)"
+            stroke="black" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
+           <title id="r4l3-label">first child is fifth level, node 3</title></a>
+          <a xlink:href="#r5n4" aria-labelledby="r4l4-label">
+           <line x1="16" y1="21" x2="48" y2="64" marker-end="url(#FilledArrow_Marker)"
+            stroke="black" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
+          <title id="r4l4-label">second child is fifth level, node 4</title></a></g>
+       </g>
+
+       <g role="list" id="r4list2">
+        <g tabindex="0" id="r4n3" transform="translate(423 341)"
+         aria-labelledby="r4n3-label plainNodeLabel" role="listitem" 
+          aria-owns="r5list3">
+         <use xlink:href="#plainNode"/>
+          <title id="r4n3-label">Fourth row, node 3</title>
+          <a xlink:href="#r5n5" aria-labelledby="r5l5-label">
+           <line x1="-17" y1="21" x2="-49" y2="64" marker-end="url(#FilledArrow_Marker)"
+           stroke="black" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
+           <title id="42l4-label">first child is fifth level, node 5</title></a>
+          <a xlink:href="#r5n6" aria-labelledby="r4l6-label">
+           <line y1="27" y2="64" marker-end="url(#FilledArrow_Marker)"
+            stroke="black" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
+          <title id="r4l6-label">second child is fifth level, node 6</title></a></g>
+
+        <g tabindex="0" id="r4n4" transform="translate(495 341)"
+         aria-labelledby="r4n4-label plainNodeLabel" role="listitem" 
+          aria-owns="r5list4">
+         <use xlink:href="#plainNode"/>
+          <title id="r4n4-label">Fourth row, node 4</title>
+          <a xlink:href="#r5n7" aria-labelledby="r4l7-label">
+           <line y1="27" y2="64" marker-end="url(#FilledArrow_Marker)"
+            stroke="black" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
+          <title id="r4l7-label">first child is fifth level, node 7</title></a>
+          <a xlink:href="#r5n8" aria-labelledby="r4l8-label">
+           <line x1="16" y1="21" x2="49" y2="64" marker-end="url(#FilledArrow_Marker)"
+            stroke="black" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
+           <title id="r4l8-label">second child is fifth level, node 8</title></a></g>
+       </g>
+
+       <g role="list" id="r5list1">
+        <g tabindex="0" id="r5n1" transform="translate(63 433)"
+         role="listitem" aria-labelledby="r5n1-label plainNodeLabel">
+        <use xlink:href="#plainNode"/>
+          <title id="r5n1-label">Fifth row, node 1</title></g>
+
+        <g tabindex="0" id="r5n2" transform="translate(135 433)"
+         role="listitem" aria-labelledby="r5n2-label plainNodeLabel">
+        <use xlink:href="#plainNode"/>
+          <title id="r5n2-label">Fifth row, node 2</title></g>
+       </g>
+
+       <g role="list" id="r5list2">
+        <g tabindex="0" id="r5n3" transform="translate(207 433)"
+         role="listitem " aria-labelledby="r5n3-label plainNodeLabel">
+        <use xlink:href="#plainNode"/>
+          <title id="r5n3-label">Fifth row, node 3</title></g>
+
+        <g tabindex="0" id="r5n4" transform="translate(278 433)"
+         role="listitem " aria-labelledby="r5n4-label plainNodeLabel">
+        <use xlink:href="#plainNode"/>
+          <title id="r5n4-label">Fifth row, node 4</title></g>
+       </g>
+
+       <g role="list" id="r5list3">
+        <g tabindex="0" id="r5n5" transform="translate(351 433)"
+         aria-labelledby="r5n5-label shadowHostLabel" role="listitem" 
+          aria-owns="r6list1">
+          <use xlink:href="#shadowHost"/>
+          <title id="r5n5-label">Fifth row, node 5</title>
+          <a xlink:href="#r6n1" aria-labelledby="r5l1-label">
+           <line x1="-22" y1="16" x2="-115" y2="89" marker-end="url(#FilledArrow_Marker)"
+            stroke="black" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
+           <title id="r5l1-label">first child is sixth level, node 1</title></a>
+          <a xlink:href="#r6n2" aria-labelledby="r5l2-label">
+           <line x1="-15" y1="23" x2="-52" y2="80" marker-end="url(#FilledArrow_Marker)"
+            stroke="black" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
+          <title id="r5l2-label">second child is sixth level, node 2</title></a></g>
+
+        <g tabindex="0" id="r5n6" transform="translate(423 433)"
+          role="listitem" aria-labelledby="r5n6-label plainNodeLabel">
+          <use xlink:href="#plainNode"/>
+          <title id="r5n6-label">Fifth row, node 6</title></g>
+       </g>
+
+        <g role="list" id="r5list4">
+          <g tabindex="0" id="r5n7" transform="translate(495 433)"
+            role="listitem " aria-labelledby="r5n7-label plainNodeLabel">
+            <use xlink:href="#plainNode"/>
+            <title id="r5n7-label">Fifth row, node 7</title></g>
+
+          <g id="r5n8" transform="translate(567 433)" tabindex="0"
+            aria-labelledby="r5n8-label shadowHostLabel"
+            role="listitem" aria-owns="r6list2">
+            <use xlink:href="#shadowHost"/>
+            <title id="r5n8-label">Fifth row, node 8</title>
+            <a xlink:href="#r6n3" aria-labelledby="r5l3-label">
+              <line x1="-24" y1="13" x2="-166" y2="93" marker-end="url(#FilledArrow_Marker)"
+                stroke="black" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
+              <title id="r5l13-label">first child is sixth level, node 3</title></a>
+            <a xlink:href="#r6n4" aria-labelledby="r5l4-label">
+              <line x1="-23" y1="18" x2="-98" y2="93" marker-end="url(#FilledArrow_Marker)"
+                stroke="black" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
+              <title id="r5l4-label">second child is sixth level, node 4</title></a>
+            <a xlink:href="#r6n5" aria-labelledby="r5l5-label">
+              <line x1="9" y1="26" x2="29" y2="77" marker-end="url(#FilledArrow_Marker)"
+                stroke="black" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
+              <title id="r5l5-label">third child is sixth level, node 5</title></a>
+            <a xlink:href="#r6n6" aria-labelledby="r5l6-label">
+              <line x1="-7" y1="26" x2="-20" y2="76" marker-end="url(#FilledArrow_Marker)"
+                stroke="black" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
+              <title id="r5l6-label">fourth child is sixth level, node 6</title></a></g>
+        </g>
+
+        <g role="list" id="r6list1">
+          <g tabindex="0" id="r6n1" transform="translate(207 545)"
+           role="listitem" aria-labelledby="r6n1-label plainNodeLabel">
+          <use xlink:href="#plainNode"/>
+            <title id="r6n1-label">Sixth row, node 1</title></g>
+
+          <g tabindex="0" id="r6n2" transform="translate(280 545)"
+           role="listitem" aria-labelledby="r6n2-label plainNodeLabel">
+          <use xlink:href="#plainNode"/>
+            <title id="r6n2-label">Sixth row, node 2</title></g>
+        </g>
+
+        <g role="list" id="r6list2">
+          <g tabindex="0" id="r6n3" transform="translate(369 545)"
+            role="listitem" aria-labelledby="r6n3-label plainNodeLabel">
+            <use xlink:href="#plainNode"/>
+            <title id="r6n3-label">Sixth row, node 3</title></g>
+
+          <g tabindex="0" id="r6n4" transform="translate(441 545)"
+            role="listitem" aria-labelledby="r6n4-label plainNodeLabel">
+            <use xlink:href="#plainNode"/>
+            <title id="r6n4-label">Sixth row, node 4</title></g>
+
+          <g tabindex="0" id="r6n5" transform="translate(537 545)"
+            role="listitem" aria-labelledby="r6n5-label plainNodeLabel">
+            <use xlink:href="#plainNode"/>
+            <title id="r6n5-label">Sixth row, node 5</title></g>
+
+          <g tabindex="0" id="r6n6" transform="translate(609 545)"
+            role="listitem" aria-labelledby="r6n6-label plainNodeLabel">
+            <use xlink:href="#plainNode"/>
+            <title id="r6n6-label">Sixth row, node 6</title></g>
+        </g>
+
       </g>
-      <line x1="309" y1="88" x2="294" y2="120" marker-end="url(#FilledArrow_Marker)" stroke="black" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
-      <line x1="329" y1="89" x2="339" y2="119" marker-end="url(#FilledArrow_Marker)" stroke="black" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
-
-      <line x1="262" y1="176" x2="230" y2="217" marker-end="url(#FilledArrow_Marker)" stroke="black" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
-      <line x1="279" y1="182" x2="279" y2="209" marker-end="url(#FilledArrow_Marker)" stroke="black" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
-      <line x1="351" y1="182" x2="351" y2="209" marker-end="url(#FilledArrow_Marker)" stroke="black" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
-      <line x1="368" y1="176" x2="400" y2="217" marker-end="url(#FilledArrow_Marker)" stroke="black" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
-
-      <line x1="190" y1="269" x2="158" y2="311" marker-end="url(#FilledArrow_Marker)" stroke="black" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
-      <line x1="207" y1="274" x2="207" y2="303" marker-end="url(#FilledArrow_Marker)" stroke="black" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
-      <line x1="423" y1="274" x2="423" y2="303" marker-end="url(#FilledArrow_Marker)" stroke="black" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
-      <line x1="439" y1="268" x2="472" y2="311" marker-end="url(#FilledArrow_Marker)" stroke="black" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
-
-      <line x1="118" y1="362" x2="86" y2="403" marker-end="url(#FilledArrow_Marker)" stroke="black" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
-      <line x1="135" y1="368" x2="135" y2="395" marker-end="url(#FilledArrow_Marker)" stroke="black" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
-      <line x1="207" y1="368" x2="207" y2="395" marker-end="url(#FilledArrow_Marker)" stroke="black" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
-      <line x1="223" y1="362" x2="255" y2="403" marker-end="url(#FilledArrow_Marker)" stroke="black" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
-      <line x1="406" y1="362" x2="374" y2="403" marker-end="url(#FilledArrow_Marker)" stroke="black" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
-      <line x1="423" y1="368" x2="423" y2="395" marker-end="url(#FilledArrow_Marker)" stroke="black" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
-      <line x1="495" y1="368" x2="495" y2="395" marker-end="url(#FilledArrow_Marker)" stroke="black" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
-      <line x1="511" y1="362" x2="544" y2="403" marker-end="url(#FilledArrow_Marker)" stroke="black" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
-
-      <line x1="329" y1="449" x2="236" y2="522" marker-end="url(#FilledArrow_Marker)" stroke="black" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
-      <line x1="336" y1="456" x2="299" y2="513" marker-end="url(#FilledArrow_Marker)" stroke="black" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
-      <line x1="543" y1="446" x2="401" y2="526" marker-end="url(#FilledArrow_Marker)" stroke="black" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
-      <line x1="546" y1="451" x2="469" y2="520.3037" marker-end="url(#FilledArrow_Marker)" stroke="black" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
-      <line x1="576" y1="459" x2="596" y2="510" marker-end="url(#FilledArrow_Marker)" stroke="black" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
-      <line x1="560" y1="459" x2="547" y2="509" marker-end="url(#FilledArrow_Marker)" stroke="black" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
     </g>
   </g>
 </svg>


### PR DESCRIPTION
+make the lines that link nodes into navigable links
+add grouping and aria list markup to make the tree structure clearer
+add titles to the links and nodes themselves
+reorder to support keyboard navigation

For more detail see the development of
https://github.com/SVG-access-W3CG/use-case-examples/blob/master/compose
d-tree-links.svg and then
https://github.com/SVG-access-W3CG/use-case-examples/blob/master/compose
d-tree-aria-list.svg for more detailed progression
