### PR TITLE
typo

### DIFF
--- a/rectrack2-notes.html
+++ b/rectrack2-notes.html
@@ -95,7 +95,7 @@
 
   <p>If <code>aria-flowto</code> <strong>worked</strong> it would be useful, but as far as I know it works in one screenreader on two browsers on one OS - i.e. is useful only to a tiny proportion of the people who need to navigate the structure. I expect to do some more experiments using tabindex and links.</p>
 
-  <p>This hasn't been very carefully tested yet, so there might be lots more problems. Please <a href="https://github.com/SVG-access-W3CG/use-case-examples/issues">file issues</a> or <https://github.com/SVG-access-W3CG/use-case-examples/blob/gh-pages/rectrack2-notes.html>Edit this document and make Pull requests</a>!</p>
+  <p>This hasn't been very carefully tested yet, so there might be lots more problems. Please <a href="https://github.com/SVG-access-W3CG/use-case-examples/issues">file issues</a> or <a href="https://github.com/SVG-access-W3CG/use-case-examples/blob/gh-pages/rectrack2-notes.html">Edit this document and make Pull requests</a>!</p>
 
   <p>It would be good if <code>title</code>-derived tooltips were easier to get for visual users. I'll probably just put a white backdrop into various groups to do this</p>
 


### PR DESCRIPTION
links don't work if you don't get the markup right
